### PR TITLE
Add Schema Reference documentation section and navigation

### DIFF
--- a/_includes/future-nav.html
+++ b/_includes/future-nav.html
@@ -7,6 +7,7 @@
   <ul class="future-nav__links">
     <li><a href="{{ '/future/' | relative_url }}" class="future-nav__link">Home</a></li>
     <li><a href="{{ '/future/blog/' | relative_url }}" class="future-nav__link">Blog</a></li>
+    <li><a href="{{ '/future/schemas/' | relative_url }}" class="future-nav__link">Schema Reference</a></li>
     <li><a href="https://github.com/debrief/debrief-future" class="future-nav__link">GitHub</a></li>
     <li><a href="{{ '/' | relative_url }}" class="future-nav__link">Legacy Debrief</a></li>
   </ul>

--- a/future/index.html
+++ b/future/index.html
@@ -79,6 +79,22 @@ description: Modernising maritime analysis for the next generation
   </section>
 
   <section class="mt-12">
+    <h2>Reference</h2>
+    <p>
+      Auto-generated reference for the LinkML schemas that define Debrief's data model: maritime
+      tracks, reference locations, analysis tool metadata, and session state. Updated automatically
+      on every <a href="https://github.com/debrief/debrief-future">debrief-future</a> release.
+    </p>
+    <div class="future-cards mt-6">
+      <a href="{{ '/future/schemas/' | relative_url }}" class="future-card future-card--clickable">
+        <span class="future-card__track">Documentation</span>
+        <h3 class="future-card__title">Schema Reference</h3>
+        <p class="future-card__excerpt">Browse every class, slot, enum, and type in the Debrief data model. Searchable, cross-linked, and regenerated from the LinkML sources on each merge.</p>
+      </a>
+    </div>
+  </section>
+
+  <section class="mt-12">
     <h2>Core Principles</h2>
     <p>
       The <a href="https://github.com/debrief/debrief-future/blob/main/CONSTITUTION.md">Constitution</a> defines
@@ -235,6 +251,7 @@ description: Modernising maritime analysis for the next generation
   <section class="mt-12 mb-12">
     <h2>Links</h2>
     <ul>
+      <li><a href="{{ '/future/schemas/' | relative_url }}">Schema Reference</a> - LinkML data model documentation</li>
       <li><a href="https://github.com/debrief/debrief-future">GitHub Repository</a> - Source code and specifications</li>
       <li><a href="https://github.com/debrief/debrief-future/blob/main/VISION.md">Vision Document</a> - Strategic context and goals</li>
       <li><a href="https://github.com/debrief/debrief-future/blob/main/ARCHITECTURE.md">Architecture</a> - Technical design decisions</li>


### PR DESCRIPTION
## Summary
This PR adds a new Schema Reference section to the Debrief Future website, providing auto-generated documentation for the LinkML schemas that define the data model. The reference is now accessible via navigation and prominently featured on the homepage.

## Key Changes
- **New Reference Section**: Added a dedicated "Reference" section on the homepage with a card linking to the schema documentation
- **Navigation Update**: Added "Schema Reference" link to the main navigation menu in `future-nav.html`
- **Links Section**: Added schema reference link to the footer links list with a description of its purpose

## Implementation Details
- The schema reference documentation is auto-generated from LinkML sources and updated on every release
- The new section includes descriptive text explaining that it covers maritime tracks, reference locations, analysis tool metadata, and session state
- The schema reference card follows the existing design pattern with the "Documentation" track label and descriptive excerpt
- All links use the Jekyll `relative_url` filter for proper path resolution

https://claude.ai/code/session_01QfuHsbdPeoYfeSQHzsQBKu