### PR TITLE
Render Mermaid diagrams in future-post layout

### DIFF
--- a/_layouts/future-post.html
+++ b/_layouts/future-post.html
@@ -40,3 +40,22 @@ layout: future-default
     {% endif %}
   </article>
 </main>
+
+{% if page.content contains "language-mermaid" %}
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+  document.querySelectorAll('code.language-mermaid').forEach((code) => {
+    const pre = document.createElement('pre');
+    pre.className = 'mermaid';
+    pre.textContent = code.textContent;
+    const wrapper = code.closest('div.highlighter-rouge')
+                 || code.closest('pre')
+                 || code;
+    wrapper.replaceWith(pre);
+  });
+
+  mermaid.initialize({ startOnLoad: false, theme: 'default' });
+  await mermaid.run();
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary

Loads `mermaid@11` from jsDelivr on Future Debrief posts that contain a Mermaid fence. Retroactively renders existing diagrams in the 2026-04-24 post (and the 2026-02-13 post once it lands via the cross-repo publish flow). A Liquid `if` guard ensures non-diagram posts pay zero cost. Decision recorded as ADR-026 in `debrief/debrief-future`.

## Change

One file touched: `_layouts/future-post.html`. The guarded `<script type="module">` block from the spec is appended at the end of the layout.

## What I learned while implementing this

A few things were worth noting beyond a literal copy-paste of the spec:

### `future-post.html` has no `</body>` tag

The spec said "add the block immediately before the closing `</body>` tag" in `_layouts/future-post.html`. That tag doesn't actually live there — `future-post.html` declares `layout: future-default` in its front matter, and `_layouts/future-default.html` is what owns `<html>`, `<head>`, and `<body>`. The post layout is rendered into `{{ content }}` inside the default layout.

I placed the script at the end of `future-post.html` (after `</main>`). In the rendered output, that lands inside `<body>`, after the article and before `{% include future-footer.html %}` and the existing `track-filter.js` script. Because the tag uses `type="module"`, it's deferred by default — execution waits until DOM parse completes — so the placement still satisfies the "after the elements exist" requirement that the spec calls out as the reason for `startOnLoad: false`.

I considered editing `future-default.html` instead (where the real `</body>` lives) but rejected it: the guard reads `page.content`, which is the post's body, and the spec scopes this feature to future-post. Putting it in the default layout would also fire on non-post pages where the property may not be defined the same way.

### The 2026-02-13 post named in the spec isn't in this repo yet

Spec referenced `_posts/2026-02-13-shipped-generate-courses-and-speeds-tool.md`. That filename doesn't exist in this repo — the closest 2026-02 file is `2026-02-13-multipoint-and-multipolygon-feature-schemas.md`, which contains no Mermaid fence. The 2026-04-24 post is present (under filename `2026-04-24-un-skipping-the-webview-log-panel-e2e-suite.md`, slightly different from the spec's `building-un-skipping…` form) and contains the expected `sequenceDiagram` fence at line 39.

That's expected — Future Debrief posts arrive here via the cross-repo publish flow from `debrief-future`, and the 2026-02-13 post simply hasn't been published into this repo yet. The layout change is content-agnostic: any post with a ` ```mermaid ` fence will pick this up the moment it lands.

### Why the kramdown DOM shim is necessary

Worth restating since it's the non-obvious part of the diff. Kramdown wraps fenced code blocks like this:

```html
<div class="highlighter-rouge language-mermaid">
  <div class="highlight">
    <pre class="highlight"><code class="language-mermaid">…</code></pre>
  </div>
</div>
```

Mermaid's `run()` API targets `<pre class="mermaid">…</pre>`. The forEach loop walks each `code.language-mermaid`, builds a fresh `<pre class="mermaid">` from its text, and replaces the outermost wrapper it can find (`div.highlighter-rouge` → `pre` → fallback). The Liquid guard matches the same `language-mermaid` class kramdown emits, so the guard and the shim are tied to the same rendering contract.

### Branch name

The spec suggested `future-debrief/mermaid-rendering`, but the session was scoped to develop and push on `claude/add-mermaid-support-UgZm0`, so the branch name reflects that. Happy to rename if preferred — the diff is a single file.

## Test plan

- [ ] After GitHub Pages rebuilds, visit https://debrief.github.io/future/2026/04/24/un-skipping-the-webview-log-panel-e2e-suite.html — the `sequenceDiagram` should render as a real diagram (not raw text).
- [ ] Once the 2026-02-13 `shipped-generate-courses-and-speeds-tool` post lands via the cross-repo publish flow, its "How It Works" flowchart should render too with no further changes here.
- [ ] Open any older post (e.g. anything from 2024 or earlier). View source — there must be no `cdn.jsdelivr.net/npm/mermaid` script tag.
- [ ] DevTools console clean on both diagram and non-diagram posts.
- [ ] On a narrow viewport, diagrams should be horizontally scrollable (Mermaid default).

## Out of scope (per ADR-026)

- Vendoring `mermaid.min.js` into the repo.
- Pre-rendering diagrams to SVG at build time.
- Theming Mermaid to match the site palette (default theme for now; tunable later via `themeVariables`).
- Backfilling diagrams in old posts.

## Rollback / mitigations

- All diagrams fail with a CDN error → pin `mermaid@11` to a specific patch (e.g. `mermaid@11.4.1`).
- Layout looks visually wrong → pass `theme: 'neutral'` to `mermaid.initialize()`.
- One diagram renders, another doesn't → almost always a syntax error in that diagram's source; report back to the Future Debrief team to fix at source.

https://claude.ai/code/session_01GT3wfWBW1ntr4R4NAzSDUv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GT3wfWBW1ntr4R4NAzSDUv)_